### PR TITLE
Replace broken visitor counter with komarev.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Full-stack Developer | MSA & Performance
 
-![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FAhngbeom&count_bg=%2379C83D&title_bg=%23555555&icon=github.svg&icon_color=%23E7E7E7&title=visitors&edge_flat=false)
+![Profile Views](https://komarev.com/ghpvc/?username=Ahngbeom&color=brightgreen)
 
 </div>
 


### PR DESCRIPTION
- Remove hits.seeyoufarm.com (service unavailable)
- Use komarev.com/ghpvc for profile views counter